### PR TITLE
Immer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2026,10 +2026,10 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
-    "immutable": {
-      "version": "4.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0-rc.12.tgz",
-      "integrity": "sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A=="
+    "immer": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-3.1.2.tgz",
+      "integrity": "sha512-pi8JuvJ9c+98DlpDms/o0YLLg5khP8Qzjd8CtIGc4qVm2eoLdQGivJL266nWccofKT/oBSxnhAh/o+nmOXtLXw=="
     },
     "inflight": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "d3-array": "^2.0.3",
     "d3-fetch": "^1.1.2",
     "fast-memoize": "^2.5.1",
-    "immutable": "^4.0.0-rc.12",
+    "immer": "^3.1.2",
     "lodash-es": "^4.17.11",
     "nearley": "^2.16.0",
     "preact": "^8.4.2"

--- a/scripts/DocumentBudgetaireQueryLanguage/makeLigneBudgetFilterFromFormula.js
+++ b/scripts/DocumentBudgetaireQueryLanguage/makeLigneBudgetFilterFromFormula.js
@@ -1,5 +1,5 @@
 import nearley from 'nearley';
-import memoize from 'fast-memoize'
+import memoize from '../memoize.js'
 
 import grammar from './grammar.js'
 

--- a/scripts/components/Aggregation.js
+++ b/scripts/components/Aggregation.js
@@ -4,13 +4,13 @@ import AggregationAnalysis from './AggregationAnalysis.js'
 import AggregationDescriptionEditor from './AggregationDescriptionEditor.js'
 
 
-export default function({aggregationDescription, aggregatedDocumentBudgetaire, documentBudgetairesWithPlanDeCompte, selectedList, aggregationDescriptionMutations, triggerAggregationDescriptionDownload, importAggregationDescription}){
+export default function({aggregationDescription, aggregatedDocumentBudgetaire, documentBudgetairesWithPlanDeCompte, selectedList, aggregationDescriptionMutations, millerColumnSelection, triggerAggregationDescriptionDownload, importAggregationDescription}){
 
     const planDeCompte = documentBudgetairesWithPlanDeCompte[0] && documentBudgetairesWithPlanDeCompte[0].planDeCompte
 
     return html`
         <div>
-            <${AggregationDescriptionEditor} ...${ {aggregationDescription, aggregatedDocumentBudgetaire, selectedList, aggregationDescriptionMutations, triggerAggregationDescriptionDownload, importAggregationDescription, planDeCompte} } />
+            <${AggregationDescriptionEditor} ...${ {aggregationDescription, aggregatedDocumentBudgetaire, selectedList, aggregationDescriptionMutations, millerColumnSelection, triggerAggregationDescriptionDownload, importAggregationDescription, planDeCompte} } />
             <${AggregationAnalysis} ...${ {aggregationDescription, documentBudgetairesWithPlanDeCompte} } />
         </div>
     `

--- a/scripts/components/AggregationAnalysis.js
+++ b/scripts/components/AggregationAnalysis.js
@@ -1,4 +1,3 @@
-import { Set as ImmutableSet } from 'immutable';
 import debounce from 'lodash-es/debounce';
 import {h, Component} from 'preact'
 
@@ -7,9 +6,15 @@ import { getAggregatedDocumentBudgetaireLeaves } from '../finance/AggregationDat
 
 function makeUnusedLigneBudgetSet(documentBudgetaire, aggregatedDocumentBudgetaire){
     const leaves = getAggregatedDocumentBudgetaireLeaves(aggregatedDocumentBudgetaire)
-    const usedLigneBudgets = ImmutableSet.union(leaves.map(l => l.elements))
+    const usedLigneBudgets = new Set()
+    
+    for(const leaf of leaves){
+        for(const lb of leaf.elements){
+            usedLigneBudgets.add(lb);
+        }
+    }
 
-    return documentBudgetaire.rows.filter(ligneBudget => !usedLigneBudgets.has(ligneBudget)).toArray()
+    return [...documentBudgetaire.rows].filter(ligneBudget => !usedLigneBudgets.has(ligneBudget))
 }
 
 function makeUsedMoreThanOnceLigneBudgetSet(documentBudgetaire, aggregatedDocumentBudgetaire){

--- a/scripts/components/AggregationDescriptionLeafEditor.js
+++ b/scripts/components/AggregationDescriptionLeafEditor.js
@@ -72,45 +72,50 @@ export default function AggregationDescriptionLeafEditor({
             <div>
                 <strong>Formule</strong> <a class="help" target="_blank" href="./exemples_formules.html">?</a>
                 <${FormulaEditor} key=${id} formula=${formula} onFormulaChange=${onFormulaChange}/>
-                <table class="summary">
-                    <tr>
-                        <td>Nombre d'éléments</td>
-                        <td>
-                            <strong>
-                                ${aggregatedDocumentBudgetaireNodeElements(aggregatedDocumentBudgetaireCorrespondingNode).size}
-                            </strong>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>Total</td>
-                        <td class="money-amount">
-                            <strong>
-                            ${aggregatedDocumentBudgetaireNodeTotal(aggregatedDocumentBudgetaireCorrespondingNode).toLocaleString('fr-FR', {style: 'currency', currency: 'EUR'})}
-                            </strong>
-                        </td>
-                    </tr>
-                </table>
-                <table class="formula-rows">
-                    <thead>
-                        <tr>
-                            ${['RDFI', 'Fonction', 'Nature', 'Montant'].map(s => html`<th>${s}</th>`)}
-                        </tr>
-                    </thead>
-                    <tbody>
-                        ${
-                            aggregatedDocumentBudgetaireCorrespondingNode.elements
-                                .toArray().sort((r1, r2) => r2['MtReal'] - r1['MtReal']).map(r => {
-                                return html`
-                                    <tr>
-                                        <td>${r['CodRD']+planDeCompte.ligneBudgetFI(r)}</td>
-                                        <td>${r['Fonction']}</td>
-                                        <td>${r['Nature']}</td>
-                                        <td class="money-amount">${r['MtReal'].toLocaleString('fr-FR', {style: 'currency', currency: 'EUR'})}</td>
-                                    </tr>`
-                            })
-                        }      
-                    </tbody>
-                </table>
+                
+                ${
+                    aggregatedDocumentBudgetaireCorrespondingNode ?
+                        html`<table class="summary">
+                            <tr>
+                                <td>Nombre d'éléments</td>
+                                <td>
+                                    <strong>
+                                        ${aggregatedDocumentBudgetaireCorrespondingNode.elements.size}
+                                    </strong>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Total</td>
+                                <td class="money-amount">
+                                    <strong>
+                                    ${aggregatedDocumentBudgetaireNodeTotal(aggregatedDocumentBudgetaireCorrespondingNode).toLocaleString('fr-FR', {style: 'currency', currency: 'EUR'})}
+                                    </strong>
+                                </td>
+                            </tr>
+                        </table>
+                        <table class="formula-rows">
+                            <thead>
+                                <tr>
+                                    ${['RDFI', 'Fonction', 'Nature', 'Montant'].map(s => html`<th>${s}</th>`)}
+                                </tr>
+                            </thead>
+                            <tbody>
+                                ${
+                                    [...aggregatedDocumentBudgetaireCorrespondingNode.elements]
+                                        .sort((r1, r2) => r2['MtReal'] - r1['MtReal']).map(r => {
+                                        return html`
+                                            <tr>
+                                                <td>${r['CodRD']+planDeCompte.ligneBudgetFI(r)}</td>
+                                                <td>${r['Fonction']}</td>
+                                                <td>${r['Nature']}</td>
+                                                <td class="money-amount">${r['MtReal'].toLocaleString('fr-FR', {style: 'currency', currency: 'EUR'})}</td>
+                                            </tr>`
+                                    })
+                                }      
+                            </tbody>
+                        </table>` :
+                        undefined
+                    }
             </div>
         </div>
     `    

--- a/scripts/entry/formula-examples.js
+++ b/scripts/entry/formula-examples.js
@@ -1,5 +1,5 @@
 import Bouture from 'https://cdn.jsdelivr.net/gh/DavidBruant/bouture@13cb6c683fa87e5feea574311dcda6353489bb3b/bouture.js'
-import memoize from 'fast-memoize'
+import memoize from '../memoize.js'
 import { sum } from 'd3-array';
 import { xml } from 'd3-fetch';
 

--- a/scripts/entry/formula-examples.js
+++ b/scripts/entry/formula-examples.js
@@ -10,7 +10,7 @@ import {fromXMLDocument} from '../finance/planDeCompte.js'
 function makeTable(rows, year, planDeCompte) {
     return Bouture.section([
         Bouture.h1('CA Gironde ', year),
-        Bouture.h2(rows.size, ' elements | ', sum(rows.map(r => r['MtReal'])).toFixed(2) + '€'),
+        Bouture.h2(rows.length, ' elements | ', sum(rows.map(r => r['MtReal'])).toFixed(2) + '€'),
         Bouture.table([
             Bouture.thead.tr(['RD', 'FI', 'Fonction', 'Nature', 'Montant'].map(t => Bouture.th(t))),
             Bouture.tbody(
@@ -22,7 +22,7 @@ function makeTable(rows, year, planDeCompte) {
                         Bouture.td(r['Nature']),
                         Bouture.td(r['MtReal'].toFixed(2) + '€')
                     ])
-                }).toArray()
+                })
             )
         ])
     ])
@@ -36,7 +36,7 @@ const docBudgP = xml('./data/CA/CA2017BPAL.xml')
 .catch(console.error)
 
 docBudgP
-.then(docBudg => console.log('docBudg', docBudg.toJS()))
+.then(docBudg => console.log('docBudg', docBudg))
 
 document.addEventListener('DOMContentLoaded', e => {
     const input = document.body.querySelector('input');

--- a/scripts/entry/main.js
+++ b/scripts/entry/main.js
@@ -1,8 +1,5 @@
-import { OrderedMap } from 'immutable';
 import {h, render} from 'preact'
 import {csv, xml, text} from 'd3-fetch';
-
-import {AggregationDescription} from '../finance/AggregationDataStructures.js'
 
 import xmlDocumentToDocumentBudgetaire from '../finance/xmlDocumentToDocumentBudgetaire.js'
 import makeNatureToChapitreFI from '../finance/makeNatureToChapitreFI.js'
@@ -14,16 +11,16 @@ import store from '../store.js'
 
 import { getStoredState, saveState } from '../stateStorage.js'
 
-import montreuilCVSToAggregationFormulas from '../montreuilCVSToAggregationFormulas.js'
+//import montreuilCVSToAggregationFormulas from '../montreuilCVSToAggregationFormulas.js'
 
 const actions =_actions(store);
 
 // initialize store
-store.mutations.aggregationDescription.set(new AggregationDescription({
+store.mutations.aggregationDescription.set({
 	id: 'racine',
 	name: 'racine',
-	children: new OrderedMap()
-}))
+	children: Object.create(null)
+})
 
 
 const isMontreuil = new Set((new URLSearchParams(location.search)).keys()).has('montreuil')
@@ -37,7 +34,7 @@ if(isMontreuil){
 	])
 	.then(([doc, natureToChapitreFI]) => xmlDocumentToDocumentBudgetaire(doc, natureToChapitreFI))
 	.then(docBudg => {
-		console.log('docBudg', docBudg.toJS())
+		console.log('docBudg', docBudg)
 		store.mutations.testedDocumentBudgetaire.setValue(docBudg)
 		return docBudg
 	})
@@ -68,7 +65,7 @@ else{
 	const storedAggregationDescription = getStoredState()
 
 	if(storedAggregationDescription){
-		console.log('storedAggregationDescription', storedAggregationDescription.toJS())
+		console.log('storedAggregationDescription', storedAggregationDescription)
 		store.mutations.aggregationDescription.set(storedAggregationDescription)
 	}
 
@@ -90,7 +87,6 @@ renderUI()
 
 // render when state changes
 store.subscribe(renderUI)
-
 
 // Save state regularly
 store.subscribe(saveState)

--- a/scripts/finance/DocBudgDataStructures.js
+++ b/scripts/finance/DocBudgDataStructures.js
@@ -31,11 +31,3 @@ export const DocumentBudgetaire = Record({
     'IdColl': undefined,
     'rows': undefined
 });
-
-export function makeLigneBudgetId(ligneBudget){
-    return [
-        ligneBudget['CodRD'],
-        ligneBudget['Fonction'],
-        ligneBudget['Nature']
-    ].join(' ');
-}

--- a/scripts/finance/makeAggregateFunction.js
+++ b/scripts/finance/makeAggregateFunction.js
@@ -1,6 +1,5 @@
-import memoize from 'fast-memoize'
+import memoize from '../memoize.js'
 
-import {AggregatedDocumentBudgetaire, AggregatedDocumentBudgetaireLeaf} from './AggregationDataStructures.js'
 import makeLigneBudgetFilterFromFormula from '../DocumentBudgetaireQueryLanguage/makeLigneBudgetFilterFromFormula.js'
 
 export default memoize(function makeAggregateFunction(aggregationDescription, planDeCompte){
@@ -10,15 +9,15 @@ export default memoize(function makeAggregateFunction(aggregationDescription, pl
 
         return children ?
             // non-leaf
-            AggregatedDocumentBudgetaire({
+            {
                 id, name, 
-                children: children.map(n => aggregationDescriptionNodeToAggregatedDocumentBudgetaireNode(n, documentBudgetaire, planDeCompte))
-            }) :
+                children: Object.values(children).map(n => aggregationDescriptionNodeToAggregatedDocumentBudgetaireNode(n, documentBudgetaire, planDeCompte))
+            } :
             // leaf, has .formula
-            AggregatedDocumentBudgetaireLeaf({
+            {
                 id, name, 
-                elements: documentBudgetaire.rows.filter(makeLigneBudgetFilterFromFormula(formula, planDeCompte))
-            })
+                elements: new Set([...documentBudgetaire.rows].filter(makeLigneBudgetFilterFromFormula(formula, planDeCompte)))
+            }
     });
 
     return memoize(function aggregate(docBudg){

--- a/scripts/finance/makeLigneBudgetId.js
+++ b/scripts/finance/makeLigneBudgetId.js
@@ -1,0 +1,8 @@
+
+export function makeLigneBudgetId(ligneBudget){
+    return [
+        ligneBudget['CodRD'],
+        ligneBudget['Fonction'],
+        ligneBudget['Nature']
+    ].join(' ');
+}

--- a/scripts/finance/xmlDocumentToDocumentBudgetaire.js
+++ b/scripts/finance/xmlDocumentToDocumentBudgetaire.js
@@ -1,14 +1,14 @@
-import {Set as ImmutableSet} from 'immutable';
-
 import {sum} from 'd3-array';
 
-import {makeLigneBudgetId, LigneBudgetRecord,  DocumentBudgetaire} from './DocBudgDataStructures';
+import {makeLigneBudgetId} from './makeLigneBudgetId.js';
 
 export default function xmlDocumentToDocumentBudgetaire(doc){
     const BlocBudget = doc.getElementsByTagName('BlocBudget')[0];
 
     const exer = Number(BlocBudget.getElementsByTagName('Exer')[0].getAttribute('V'))
 
+    // In the XML files, the same (CodRD, Nature, Fonction) tuple can appear
+    // We consider them as a single LigneBudget
     const xmlRowsById = new Map();
 
     const lignes = Array.from(doc.getElementsByTagName('LigneBudget'))
@@ -43,24 +43,23 @@ export default function xmlDocumentToDocumentBudgetaire(doc){
         xmlRowsById.set(id, idRows);
     }
 
-    return DocumentBudgetaire({
+    return {
         LibelleColl: doc.getElementsByTagName('LibelleColl')[0].getAttribute('V'),
         Nomenclature: doc.getElementsByTagName('Nomenclature')[0].getAttribute('V'),
         NatDec: BlocBudget.getElementsByTagName('NatDec')[0].getAttribute('V'),
         Exer: exer,
         IdColl: doc.getElementsByTagName('IdColl')[0].getAttribute('V'),
 
-        rows: ImmutableSet(Array.from(xmlRowsById.values())
-        .map(xmlRows => {
-            const amount = sum(xmlRows.map(r => Number(r['MtReal'])))
-            const r = xmlRows[0];
+        rows: [...xmlRowsById.values()]
+            .map(xmlRows => {
+                const amount = sum(xmlRows.map(r => Number(r['MtReal'])))
+                const r = xmlRows[0];
 
-            return LigneBudgetRecord(Object.assign(
-                {},
-                r,
-                {'MtReal': amount}
-            ))
-        }))
-    })
+                return Object.freeze({
+                    ...r,
+                    'MtReal': amount
+                })
+            })
+    }
 
 }

--- a/scripts/finance/xmlDocumentToDocumentBudgetaire.js
+++ b/scripts/finance/xmlDocumentToDocumentBudgetaire.js
@@ -50,7 +50,7 @@ export default function xmlDocumentToDocumentBudgetaire(doc){
         Exer: exer,
         IdColl: doc.getElementsByTagName('IdColl')[0].getAttribute('V'),
 
-        rows: [...xmlRowsById.values()]
+        rows: new Set([...xmlRowsById.values()]
             .map(xmlRows => {
                 const amount = sum(xmlRows.map(r => Number(r['MtReal'])))
                 const r = xmlRows[0];
@@ -59,7 +59,7 @@ export default function xmlDocumentToDocumentBudgetaire(doc){
                     ...r,
                     'MtReal': amount
                 })
-            })
+            }))
     }
 
 }

--- a/scripts/memoize.js
+++ b/scripts/memoize.js
@@ -1,0 +1,42 @@
+import fastMemoize from 'fast-memoize'
+
+// fast-memoize uses JSON.stringify(arguments) as default serializer
+// It doesn't work well with Set/Map/WeakSet/WeakMap which always serialize to '{}'
+
+function Serializer(){
+    const objectCounter = new WeakMap()
+    let next = 1;
+
+    return function(...args){
+        return args.map(arg => {
+            if(arg === null || arg === undefined || typeof arg === 'boolean'){
+                return String(arg)
+            }
+
+            switch(typeof arg){
+                case 'number':
+                case 'string': {
+                    return `${typeof arg}(${arg})`
+                }
+                case 'object': // null handled above
+                case 'symbol': {
+                    let id = objectCounter.get(arg);
+                    if(id === undefined){
+                        id = next;
+                        objectCounter.set(arg, id)
+                        next++
+                    }
+                    return id;
+                }
+                default: {
+                    console.error('Unhandled type', typeof arg)
+                    return 'Ser'+Math.random().toString(36).slice(2)
+                }
+            }
+        }).join(' ')
+    }
+}
+
+export default function memoize(fn){
+    return fastMemoize(fn, {serializer: new Serializer()})
+}


### PR DESCRIPTION
Beaucoup de changements mécaniques qui aboutissent à du code un peu plus léger (absence de `toArray` et de `toJS`)

La simplification du code du store est en partie dû à immer et en partie dû à un déplacement de la complexité de `store.js` vers `scripts/components/AggregationDescriptionEditor.js`

Mauvaise surprise sur fast-memoize qui ne prend pas bien en compte les `Set` et a nécessité un taf supplémentaire

Côté taille de fichier, on passe de ~272ko à ~156ko (59/37,7 après gzip)